### PR TITLE
Target Framework Change To Multi-targeting .netstandard2.0;.netstanda…

### DIFF
--- a/ADotNet/ADotNet.csproj
+++ b/ADotNet/ADotNet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
 		<Copyright>Copyright (c) Hassan Habib &amp; Shri Humrudha</Copyright>
 		<Description>ADotNet is a dot net library to help engineers develop their build and release pipelines in C# without having to use YAML or any other technology.</Description>
 		<Authors>Hassan Habib &amp; Shri Humrudha</Authors>

--- a/ADotNet/Properties/Resources.Designer.cs
+++ b/ADotNet/Properties/Resources.Designer.cs
@@ -82,7 +82,7 @@ namespace ADotNet.Properties {
         ///
         ///The MIT License (MIT)
         ///
-        ///Permission is hereby granted, free of charge, to any person obtai [rest of string was truncated]&quot;;.
+        ///Permission is hereby granted, free of charge, to any p [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string License {
             get {


### PR DESCRIPTION
…rd2.1

I suggest this (and all of your other "pure" libraries should be multi-targeting .Net Standard versions.
Before merging this commit, please see the concomitant commit in your Xception repo that I have submitted in tandem with this one: https://github.com/hassanhabib/Xeption/pull/43 

Note: After pulling this branch down, you will have to update your Xception Nuget package version with the concomitant update.