### PR TITLE
EXPOSURES: DotNetBuildTaskBuilder

### DIFF
--- a/ADotNet.sln
+++ b/ADotNet.sln
@@ -14,6 +14,10 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{16CB1804-3040-41F0-9C1F-99A139B24873}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
+		.gitattributes = .gitattributes
+		.gitignore = .gitignore
+		gitHubPipelines.yaml = gitHubPipelines.yaml
+		README.md = README.md
 	EndProjectSection
 EndProject
 Global

--- a/ADotNet/Models/Pipelines/GithubPipelines/DotNets/TaskBuilders/DotNetBuildTaskBuilder.cs
+++ b/ADotNet/Models/Pipelines/GithubPipelines/DotNets/TaskBuilders/DotNetBuildTaskBuilder.cs
@@ -1,0 +1,45 @@
+﻿// ---------------------------------------------------------------------------
+// Copyright (c) Hassan Habib & Shri Humrudha Jagathisun All rights reserved.
+// Licensed under the MIT License.
+// See License.txt in the project root for license information.
+// ---------------------------------------------------------------------------
+
+using ADotNet.Models.Pipelines.GithubPipelines.DotNets.Tasks;
+
+namespace ADotNet.Models.Pipelines.GithubPipelines.DotNets.TaskBuilders
+{
+    public class DotNetBuildTaskBuilder
+    {
+        private DotNetBuildTask dotnetBuildTask;
+
+        public DotNetBuildTaskBuilder()
+        {
+            this.dotnetBuildTask = new DotNetBuildTask
+            {
+                Run = "dotnet build"
+            };
+        }
+
+        public DotNetBuildTaskBuilder WithName(string name)
+        {
+            this.dotnetBuildTask.Name = name;
+            return this;
+        }
+
+        public DotNetBuildTaskBuilder WithRestore(bool restore)
+        {
+            this.dotnetBuildTask.Restore = restore;
+            return this;
+        }
+
+        public DotNetBuildTask Build()
+        {
+            if (!this.dotnetBuildTask.Restore)
+            {
+                this.dotnetBuildTask.Run += " --no-restore";
+            }
+
+            return this.dotnetBuildTask;
+        }
+    }
+}

--- a/ADotNet/Models/Pipelines/GithubPipelines/DotNets/TaskBuilders/DotNetBuildTaskBuilder.cs
+++ b/ADotNet/Models/Pipelines/GithubPipelines/DotNets/TaskBuilders/DotNetBuildTaskBuilder.cs
@@ -26,7 +26,7 @@ namespace ADotNet.Models.Pipelines.GithubPipelines.DotNets.TaskBuilders
             return this;
         }
 
-        public DotNetBuildTaskBuilder WithRestore(bool restore)
+        public DotNetBuildTaskBuilder WithRestore(bool restore = true)
         {
             this.dotnetBuildTask.Restore = restore;
             return this;

--- a/ADotNet/Models/Pipelines/GithubPipelines/DotNets/TaskBuilders/NuGetPushTaskBuilder.cs
+++ b/ADotNet/Models/Pipelines/GithubPipelines/DotNets/TaskBuilders/NuGetPushTaskBuilder.cs
@@ -1,0 +1,64 @@
+﻿// ---------------------------------------------------------------------------
+// Copyright (c) Hassan Habib & Shri Humrudha Jagathisun All rights reserved.
+// Licensed under the MIT License.
+// See License.txt in the project root for license information.
+// ---------------------------------------------------------------------------
+
+using ADotNet.Models.Pipelines.GithubPipelines.DotNets.Tasks;
+
+namespace ADotNet.Models.Pipelines.GithubPipelines.DotNets.TaskBuilders
+{
+    public class NuGetPushTaskBuilder
+    {
+        private NuGetPushTask nugetPushTask;
+
+        public NuGetPushTaskBuilder()
+        {
+            this.nugetPushTask = new NuGetPushTask();
+        }
+
+        public NuGetPushTaskBuilder WithName(string name)
+        {
+            this.nugetPushTask.Name = name;
+            return this;
+        }
+
+        public NuGetPushTaskBuilder WithSearchPath(string searchPath)
+        {
+            this.nugetPushTask.SearchPath = searchPath;
+            return this;
+        }
+
+        public NuGetPushTaskBuilder WithApiKey(string apiKey)
+        {
+            this.nugetPushTask.ApiKey = apiKey;
+            return this;
+        }
+
+        public NuGetPushTaskBuilder WithDestination(string destination)
+        {
+            this.nugetPushTask.Destination = destination;
+            return this;
+        }
+
+        public NuGetPushTask Build()
+        {
+            if (!string.IsNullOrEmpty(this.nugetPushTask.SearchPath))
+            {
+                this.nugetPushTask.Run += $" \"{this.nugetPushTask.SearchPath}\"";
+            }
+
+            if (!string.IsNullOrEmpty(this.nugetPushTask.ApiKey))
+            {
+                this.nugetPushTask.Run += $" --api-key {this.nugetPushTask.ApiKey}";
+            }
+
+            if (!string.IsNullOrEmpty(this.nugetPushTask.Destination))
+            {
+                this.nugetPushTask.Run += $" --source \"{this.nugetPushTask.Destination}\"";
+            }
+
+            return this.nugetPushTask;
+        }
+    }
+}

--- a/ADotNet/Models/Pipelines/GithubPipelines/DotNets/Tasks/Builders/DotNetBuildTaskBuilder.cs
+++ b/ADotNet/Models/Pipelines/GithubPipelines/DotNets/Tasks/Builders/DotNetBuildTaskBuilder.cs
@@ -12,30 +12,32 @@ namespace ADotNet.Models.Pipelines.GithubPipelines.DotNets.Tasks.Builders
 
         public DotNetBuildTaskBuilder()
         {
-            dotnetBuildTask = new DotNetBuildTask
-            {
-                Run = "dotnet build"
-            };
+            this.dotnetBuildTask = new DotNetBuildTask();
+            this.dotnetBuildTask.Run = "dotnet build";
         }
 
         public DotNetBuildTaskBuilder WithName(string name)
         {
-            dotnetBuildTask.Name = name;
+            this.dotnetBuildTask.Name = name;
+
             return this;
         }
 
         public DotNetBuildTaskBuilder WithRestore(bool restore = true)
         {
-            dotnetBuildTask.Restore = restore;
+            this.dotnetBuildTask.Restore = restore;
+
             return this;
         }
 
         public DotNetBuildTask Build()
         {
-            if (!dotnetBuildTask.Restore)
-                dotnetBuildTask.Run += " --no-restore";
+            if (this.dotnetBuildTask.Restore is false)
+            {
+                this.dotnetBuildTask.Run += " --no-restore";
+            }
 
-            return dotnetBuildTask;
+            return this.dotnetBuildTask;
         }
     }
 }

--- a/ADotNet/Models/Pipelines/GithubPipelines/DotNets/Tasks/Builders/DotNetBuildTaskBuilder.cs
+++ b/ADotNet/Models/Pipelines/GithubPipelines/DotNets/Tasks/Builders/DotNetBuildTaskBuilder.cs
@@ -16,21 +16,24 @@ namespace ADotNet.Models.Pipelines.GithubPipelines.DotNets.Tasks.Builders
             this.dotnetBuildTask.Run = "dotnet build";
         }
 
-        public DotNetBuildTaskBuilder WithName(string name)
+        public static implicit operator DotNetBuildTask(DotNetBuildTaskBuilder dotnetBuildTaskBuilder) =>
+            dotnetBuildTaskBuilder.Build();
+
+        public DotNetBuildTaskBuilder Name(string name)
         {
             this.dotnetBuildTask.Name = name;
 
             return this;
         }
 
-        public DotNetBuildTaskBuilder WithRestore(bool restore = true)
+        public DotNetBuildTaskBuilder Restore(bool restore = true)
         {
             this.dotnetBuildTask.Restore = restore;
 
             return this;
         }
 
-        public DotNetBuildTask Build()
+        private DotNetBuildTask Build()
         {
             if (this.dotnetBuildTask.Restore is false)
             {

--- a/ADotNet/Models/Pipelines/GithubPipelines/DotNets/Tasks/Builders/DotNetBuildTaskBuilder.cs
+++ b/ADotNet/Models/Pipelines/GithubPipelines/DotNets/Tasks/Builders/DotNetBuildTaskBuilder.cs
@@ -4,9 +4,7 @@
 // See License.txt in the project root for license information.
 // ---------------------------------------------------------------------------
 
-using ADotNet.Models.Pipelines.GithubPipelines.DotNets.Tasks;
-
-namespace ADotNet.Models.Pipelines.GithubPipelines.DotNets.TaskBuilders
+namespace ADotNet.Models.Pipelines.GithubPipelines.DotNets.Tasks.Builders
 {
     public class DotNetBuildTaskBuilder
     {
@@ -14,7 +12,7 @@ namespace ADotNet.Models.Pipelines.GithubPipelines.DotNets.TaskBuilders
 
         public DotNetBuildTaskBuilder()
         {
-            this.dotnetBuildTask = new DotNetBuildTask
+            dotnetBuildTask = new DotNetBuildTask
             {
                 Run = "dotnet build"
             };
@@ -22,24 +20,22 @@ namespace ADotNet.Models.Pipelines.GithubPipelines.DotNets.TaskBuilders
 
         public DotNetBuildTaskBuilder WithName(string name)
         {
-            this.dotnetBuildTask.Name = name;
+            dotnetBuildTask.Name = name;
             return this;
         }
 
         public DotNetBuildTaskBuilder WithRestore(bool restore = true)
         {
-            this.dotnetBuildTask.Restore = restore;
+            dotnetBuildTask.Restore = restore;
             return this;
         }
 
         public DotNetBuildTask Build()
         {
-            if (!this.dotnetBuildTask.Restore)
-            {
-                this.dotnetBuildTask.Run += " --no-restore";
-            }
+            if (!dotnetBuildTask.Restore)
+                dotnetBuildTask.Run += " --no-restore";
 
-            return this.dotnetBuildTask;
+            return dotnetBuildTask;
         }
     }
 }

--- a/ADotNet/Models/Pipelines/GithubPipelines/DotNets/Tasks/Builders/NuGetPushTaskBuilder.cs
+++ b/ADotNet/Models/Pipelines/GithubPipelines/DotNets/Tasks/Builders/NuGetPushTaskBuilder.cs
@@ -13,35 +13,38 @@ namespace ADotNet.Models.Pipelines.GithubPipelines.DotNets.Tasks.Builders
         public NuGetPushTaskBuilder() =>
             this.nugetPushTask = new NuGetPushTask();
 
-        public NuGetPushTaskBuilder WithName(string name)
+        public static implicit operator NuGetPushTask(NuGetPushTaskBuilder nugetPushTaskBuilder) =>
+            nugetPushTaskBuilder.Build();
+
+        public NuGetPushTaskBuilder Name(string name)
         {
             this.nugetPushTask.Name = name;
 
             return this;
         }
 
-        public NuGetPushTaskBuilder WithSearchPath(string searchPath)
+        public NuGetPushTaskBuilder SearchPath(string searchPath)
         {
             this.nugetPushTask.SearchPath = searchPath;
 
             return this;
         }
 
-        public NuGetPushTaskBuilder WithApiKey(string apiKey)
+        public NuGetPushTaskBuilder ApiKey(string apiKey)
         {
             this.nugetPushTask.ApiKey = apiKey;
 
             return this;
         }
 
-        public NuGetPushTaskBuilder WithDestination(string destination)
+        public NuGetPushTaskBuilder Destination(string destination)
         {
             this.nugetPushTask.Destination = destination;
 
             return this;
         }
 
-        public NuGetPushTask Build()
+        private NuGetPushTask Build()
         {
             if (!string.IsNullOrEmpty(this.nugetPushTask.SearchPath))
             {

--- a/ADotNet/Models/Pipelines/GithubPipelines/DotNets/Tasks/Builders/NuGetPushTaskBuilder.cs
+++ b/ADotNet/Models/Pipelines/GithubPipelines/DotNets/Tasks/Builders/NuGetPushTaskBuilder.cs
@@ -4,9 +4,7 @@
 // See License.txt in the project root for license information.
 // ---------------------------------------------------------------------------
 
-using ADotNet.Models.Pipelines.GithubPipelines.DotNets.Tasks;
-
-namespace ADotNet.Models.Pipelines.GithubPipelines.DotNets.TaskBuilders
+namespace ADotNet.Models.Pipelines.GithubPipelines.DotNets.Tasks.Builders
 {
     public class NuGetPushTaskBuilder
     {
@@ -14,51 +12,45 @@ namespace ADotNet.Models.Pipelines.GithubPipelines.DotNets.TaskBuilders
 
         public NuGetPushTaskBuilder()
         {
-            this.nugetPushTask = new NuGetPushTask();
+            nugetPushTask = new NuGetPushTask();
         }
 
         public NuGetPushTaskBuilder WithName(string name)
         {
-            this.nugetPushTask.Name = name;
+            nugetPushTask.Name = name;
             return this;
         }
 
         public NuGetPushTaskBuilder WithSearchPath(string searchPath)
         {
-            this.nugetPushTask.SearchPath = searchPath;
+            nugetPushTask.SearchPath = searchPath;
             return this;
         }
 
         public NuGetPushTaskBuilder WithApiKey(string apiKey)
         {
-            this.nugetPushTask.ApiKey = apiKey;
+            nugetPushTask.ApiKey = apiKey;
             return this;
         }
 
         public NuGetPushTaskBuilder WithDestination(string destination)
         {
-            this.nugetPushTask.Destination = destination;
+            nugetPushTask.Destination = destination;
             return this;
         }
 
         public NuGetPushTask Build()
         {
-            if (!string.IsNullOrEmpty(this.nugetPushTask.SearchPath))
-            {
-                this.nugetPushTask.Run += $" \"{this.nugetPushTask.SearchPath}\"";
-            }
+            if (!string.IsNullOrEmpty(nugetPushTask.SearchPath))
+                nugetPushTask.Run += $" \"{nugetPushTask.SearchPath}\"";
 
-            if (!string.IsNullOrEmpty(this.nugetPushTask.ApiKey))
-            {
-                this.nugetPushTask.Run += $" --api-key {this.nugetPushTask.ApiKey}";
-            }
+            if (!string.IsNullOrEmpty(nugetPushTask.ApiKey))
+                nugetPushTask.Run += $" --api-key {nugetPushTask.ApiKey}";
 
-            if (!string.IsNullOrEmpty(this.nugetPushTask.Destination))
-            {
-                this.nugetPushTask.Run += $" --source \"{this.nugetPushTask.Destination}\"";
-            }
+            if (!string.IsNullOrEmpty(nugetPushTask.Destination))
+                nugetPushTask.Run += $" --source \"{nugetPushTask.Destination}\"";
 
-            return this.nugetPushTask;
+            return nugetPushTask;
         }
     }
 }

--- a/ADotNet/Models/Pipelines/GithubPipelines/DotNets/Tasks/Builders/NuGetPushTaskBuilder.cs
+++ b/ADotNet/Models/Pipelines/GithubPipelines/DotNets/Tasks/Builders/NuGetPushTaskBuilder.cs
@@ -10,10 +10,8 @@ namespace ADotNet.Models.Pipelines.GithubPipelines.DotNets.Tasks.Builders
     {
         private NuGetPushTask nugetPushTask;
 
-        public NuGetPushTaskBuilder()
-        {
+        public NuGetPushTaskBuilder() =>
             this.nugetPushTask = new NuGetPushTask();
-        }
 
         public NuGetPushTaskBuilder WithName(string name)
         {

--- a/ADotNet/Models/Pipelines/GithubPipelines/DotNets/Tasks/Builders/NuGetPushTaskBuilder.cs
+++ b/ADotNet/Models/Pipelines/GithubPipelines/DotNets/Tasks/Builders/NuGetPushTaskBuilder.cs
@@ -12,45 +12,55 @@ namespace ADotNet.Models.Pipelines.GithubPipelines.DotNets.Tasks.Builders
 
         public NuGetPushTaskBuilder()
         {
-            nugetPushTask = new NuGetPushTask();
+            this.nugetPushTask = new NuGetPushTask();
         }
 
         public NuGetPushTaskBuilder WithName(string name)
         {
-            nugetPushTask.Name = name;
+            this.nugetPushTask.Name = name;
+
             return this;
         }
 
         public NuGetPushTaskBuilder WithSearchPath(string searchPath)
         {
-            nugetPushTask.SearchPath = searchPath;
+            this.nugetPushTask.SearchPath = searchPath;
+
             return this;
         }
 
         public NuGetPushTaskBuilder WithApiKey(string apiKey)
         {
-            nugetPushTask.ApiKey = apiKey;
+            this.nugetPushTask.ApiKey = apiKey;
+
             return this;
         }
 
         public NuGetPushTaskBuilder WithDestination(string destination)
         {
-            nugetPushTask.Destination = destination;
+            this.nugetPushTask.Destination = destination;
+
             return this;
         }
 
         public NuGetPushTask Build()
         {
-            if (!string.IsNullOrEmpty(nugetPushTask.SearchPath))
-                nugetPushTask.Run += $" \"{nugetPushTask.SearchPath}\"";
+            if (!string.IsNullOrEmpty(this.nugetPushTask.SearchPath))
+            {
+                this.nugetPushTask.Run += $" \"{this.nugetPushTask.SearchPath}\"";
+            }
 
-            if (!string.IsNullOrEmpty(nugetPushTask.ApiKey))
-                nugetPushTask.Run += $" --api-key {nugetPushTask.ApiKey}";
+            if (!string.IsNullOrEmpty(this.nugetPushTask.ApiKey))
+            {
+                this.nugetPushTask.Run += $" --api-key {this.nugetPushTask.ApiKey}";
+            }
 
-            if (!string.IsNullOrEmpty(nugetPushTask.Destination))
-                nugetPushTask.Run += $" --source \"{nugetPushTask.Destination}\"";
+            if (!string.IsNullOrEmpty(this.nugetPushTask.Destination))
+            {
+                this.nugetPushTask.Run += $" --source \"{this.nugetPushTask.Destination}\"";
+            }
 
-            return nugetPushTask;
+            return this.nugetPushTask;
         }
     }
 }

--- a/ADotNet/Models/Pipelines/GithubPipelines/DotNets/Tasks/NuGetPushTask.cs
+++ b/ADotNet/Models/Pipelines/GithubPipelines/DotNets/Tasks/NuGetPushTask.cs
@@ -14,9 +14,7 @@ namespace ADotNet.Models.Pipelines.GithubPipelines.DotNets.Tasks
         public string Run = "dotnet nuget push";
 
         internal string SearchPath { get; set; }
-
         internal string ApiKey { get; set; }
-
         internal string Destination { get; set; }
     }
 }

--- a/ADotNet/Models/Pipelines/GithubPipelines/DotNets/Tasks/NuGetPushTask.cs
+++ b/ADotNet/Models/Pipelines/GithubPipelines/DotNets/Tasks/NuGetPushTask.cs
@@ -8,11 +8,15 @@ using YamlDotNet.Serialization;
 
 namespace ADotNet.Models.Pipelines.GithubPipelines.DotNets.Tasks
 {
-    public class DotNetBuildTask : GithubTask
+    public class NuGetPushTask : GithubTask
     {
         [YamlMember(Order = 1)]
-        public string Run = "dotnet build --no-restore";
+        public string Run = "dotnet nuget push";
 
-        internal bool Restore { get; set; }
+        internal string SearchPath { get; set; }
+
+        internal string ApiKey { get; set; }
+
+        internal string Destination { get; set; }
     }
 }

--- a/AdoNet.Tests.Console/Program.cs
+++ b/AdoNet.Tests.Console/Program.cs
@@ -11,6 +11,7 @@ using ADotNet.Models.Pipelines.AdoPipelines.AspNets.Tasks.DotNetExecutionTasks;
 using ADotNet.Models.Pipelines.AdoPipelines.AspNets.Tasks.PublishBuildArtifactTasks;
 using ADotNet.Models.Pipelines.AdoPipelines.AspNets.Tasks.UseDotNetTasks;
 using ADotNet.Models.Pipelines.GithubPipelines.DotNets;
+using ADotNet.Models.Pipelines.GithubPipelines.DotNets.TaskBuilders;
 using ADotNet.Models.Pipelines.GithubPipelines.DotNets.Tasks;
 using ADotNet.Models.Pipelines.GithubPipelines.DotNets.Tasks.SetupDotNetTaskV1s;
 
@@ -175,7 +176,14 @@ namespace ADotNet.Tests.Console
                             {
                                 Name = "Provision",
                                 Run = "dotnet run --project .\\OtripleS.Api.Infrastructure.Provision\\OtripleS.Web.Api.Infrastructure.Provision.csproj"
-                            }
+                            },
+
+                            new NuGetPushTaskBuilder()
+                                .WithName("Publish")
+                                .WithSearchPath(@"**\*.nupkg")
+                                .WithApiKey("${{ secrets.NUGET_API_KEY }}")
+                                .WithDestination("https://api.nuget.org/v3/index.json")
+                                .Build()
                         }
                     }
                 }

--- a/AdoNet.Tests.Console/Program.cs
+++ b/AdoNet.Tests.Console/Program.cs
@@ -11,8 +11,8 @@ using ADotNet.Models.Pipelines.AdoPipelines.AspNets.Tasks.DotNetExecutionTasks;
 using ADotNet.Models.Pipelines.AdoPipelines.AspNets.Tasks.PublishBuildArtifactTasks;
 using ADotNet.Models.Pipelines.AdoPipelines.AspNets.Tasks.UseDotNetTasks;
 using ADotNet.Models.Pipelines.GithubPipelines.DotNets;
-using ADotNet.Models.Pipelines.GithubPipelines.DotNets.TaskBuilders;
 using ADotNet.Models.Pipelines.GithubPipelines.DotNets.Tasks;
+using ADotNet.Models.Pipelines.GithubPipelines.DotNets.Tasks.Builders;
 using ADotNet.Models.Pipelines.GithubPipelines.DotNets.Tasks.SetupDotNetTaskV1s;
 
 namespace ADotNet.Tests.Console

--- a/AdoNet.Tests.Console/Program.cs
+++ b/AdoNet.Tests.Console/Program.cs
@@ -179,11 +179,10 @@ namespace ADotNet.Tests.Console
                             },
 
                             new NuGetPushTaskBuilder()
-                                .WithName("Publish")
-                                .WithSearchPath(@"**\*.nupkg")
-                                .WithApiKey("${{ secrets.NUGET_API_KEY }}")
-                                .WithDestination("https://api.nuget.org/v3/index.json")
-                                .Build()
+                                .Name("Publish")
+                                .SearchPath(@"**\*.nupkg")
+                                .ApiKey("${{ secrets.NUGET_API_KEY }}")
+                                .Destination("https://api.nuget.org/v3/index.json")
                         }
                     }
                 }


### PR DESCRIPTION
Closes #40 

I added two task builders in this PR to show a simple case and a more advanced case.

I could not remove the `--no-restore` command option from the existing `DotNetBuildTask` because that would break backwards compatibility.

So instead, I created a task builder which can be used with fluent syntax to specify optional parameters to the task.

For example:
```
new DotNetBuildTaskBuilder()
    .Name("Build")
```
will generate the following YAML snippet:
```
    - name: Build
      run: dotnet build
```

As another example:
```
new DotNetBuildTaskBuilder()
    .Name("Build")
    .Restore(false)
```
will generate the following YAML snippet:
```
    - name: Build
      run: dotnet build --no-restore
```
