### PR TITLE
Check For Release Candidate

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -8,6 +8,21 @@ on:
   pull_request:
     branches:
     - master
+env:
+  IS_RELEASE_CANDIDATE: >-
+    ${{
+      (
+        github.event_name == 'pull_request' &&
+        startsWith(github.event.pull_request.title, 'RELEASES:') &&
+        contains(github.event.pull_request.labels.*.name, 'RELEASES')
+      )
+      ||
+      (
+        github.event_name == 'push' &&
+        startsWith(github.event.head_commit.message, 'RELEASES:') &&
+        github.ref_name == 'RELEASE'
+      )
+    }}
 jobs:
   build:
     runs-on: windows-2019

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,6 +1,8 @@
 name: .Net
 on:
   push:
+    tags:
+    - RELEASE
     branches:
     - master
   pull_request:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -14,7 +14,7 @@ env:
       (
         github.event_name == 'pull_request' &&
         startsWith(github.event.pull_request.title, 'RELEASES:') &&
-        contains(github.event.pull_request.labels.*.name, 'RELEASES')
+        contains(github.event.pull_request.labels.*.name, 'RELEASE')
       )
       ||
       (

--- a/ADotNet.Infrastructure.Build/Program.cs
+++ b/ADotNet.Infrastructure.Build/Program.cs
@@ -1,9 +1,10 @@
-﻿// ---------------------------------------------------------------------------
+// ---------------------------------------------------------------------------
 // Copyright (c) Hassan Habib & Shri Humrudha Jagathisun All rights reserved.
 // Licensed under the MIT License.
 // See License.txt in the project root for license information.
 // ---------------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using ADotNet.Clients;
 using ADotNet.Models.Pipelines.GithubPipelines.DotNets;
@@ -34,6 +35,11 @@ namespace ADotNet.Infrastructure.Build
                     {
                         Branches = new string[] { "master" }
                     }
+                },
+
+                EnvironmentVariables = new Dictionary<string, string>
+                {
+                    { "IS_RELEASE_CANDIDATE", EnvironmentVariables.IsGitHubReleaseCandidate() }
                 },
 
                 Jobs = new Jobs

--- a/ADotNet.Infrastructure.Build/Program.cs
+++ b/ADotNet.Infrastructure.Build/Program.cs
@@ -26,6 +26,7 @@ namespace ADotNet.Infrastructure.Build
                 {
                     Push = new PushEvent
                     {
+                        Tags = new string[] { "RELEASE" },
                         Branches = new string[] { "master" }
                     },
 

--- a/ADotNet/Models/Pipelines/GithubPipelines/DotNets/EnvironmentVariables.cs
+++ b/ADotNet/Models/Pipelines/GithubPipelines/DotNets/EnvironmentVariables.cs
@@ -1,0 +1,26 @@
+// ---------------------------------------------------------------------------
+// Copyright (c) Hassan Habib & Shri Humrudha Jagathisun All rights reserved.
+// Licensed under the MIT License.
+// See License.txt in the project root for license information.
+// ---------------------------------------------------------------------------
+
+namespace ADotNet.Models.Pipelines.GithubPipelines.DotNets
+{
+    public sealed class EnvironmentVariables
+    {
+        public static string IsGitHubReleaseCandidate() =>
+            "${{\n"
+            + "  (\n"
+            + "    github.event_name == 'pull_request' &&\n"
+            + "    startsWith(github.event.pull_request.title, 'RELEASES:') &&\n"
+            + "    contains(github.event.pull_request.labels.*.name, 'RELEASES')\n"
+            + "  )\n"
+            + "  ||\n"
+            + "  (\n"
+            + "    github.event_name == 'push' &&\n"
+            + "    startsWith(github.event.head_commit.message, 'RELEASES:') &&\n"
+            + "    github.ref_name == 'RELEASE'\n"
+            + "  )\n"
+            + "}}";
+    }
+}

--- a/ADotNet/Models/Pipelines/GithubPipelines/DotNets/GithubPipeline.cs
+++ b/ADotNet/Models/Pipelines/GithubPipelines/DotNets/GithubPipeline.cs
@@ -4,6 +4,7 @@
 // See License.txt in the project root for license information.
 // ---------------------------------------------------------------------------
 
+using System.Collections.Generic;
 using YamlDotNet.Serialization;
 
 namespace ADotNet.Models.Pipelines.GithubPipelines.DotNets
@@ -14,6 +15,9 @@ namespace ADotNet.Models.Pipelines.GithubPipelines.DotNets
 
         [YamlMember(Alias = "on")]
         public Events OnEvents { get; set; }
+
+        [YamlMember(Alias = "env", DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)]
+        public Dictionary<string, string> EnvironmentVariables { get; set; }
 
         public Jobs Jobs { get; set; }
     }


### PR DESCRIPTION
This PR:

- adds support for top-level environment variables in GitHub workflows
- add functionality to check for the release candidates in the ADotNet build Github pipeline
- Closes #52