### PR TITLE
Add Git Tag on Merge to Main

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -44,7 +44,7 @@ jobs:
   add_tag:
     if: >
       github.event.pull_request.merged &&
-      github.event.pull_request.base.ref == 'main' &&
+      github.event.pull_request.base.ref == 'master' &&
       startsWith(github.event.pull_request.title, 'RELEASES:') &&
       contains(github.event.pull_request.labels.*.name, 'RELEASES')
     runs-on: ubuntu-latest

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -53,6 +53,8 @@ jobs:
       startsWith(github.event.pull_request.title, 'RELEASES:') &&
       contains(github.event.pull_request.labels.*.name, 'RELEASES')
     runs-on: ubuntu-latest
+    needs:
+    - build
     steps:
     - name: Checkout code
       uses: actions/checkout@v2

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -41,3 +41,30 @@ jobs:
       run: dotnet build --no-restore
     - name: Test
       run: dotnet test --no-build --verbosity normal
+  add_tag:
+    if: >
+      github.event.pull_request.merged &&
+      github.event.pull_request.base.ref == 'main' &&
+      startsWith(github.event.pull_request.title, 'RELEASES:') &&
+      contains(github.event.pull_request.labels.*.name, 'RELEASES')
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Extract Version Number
+      id: extract_version
+      run: echo "::set-output name=version_number::$(grep -oP '(?<=<Version>)[^<]+' BuildTestApp/BuildTestApp.csproj)"
+    - name: Print Version Number
+      run: echo "Version number is ${{ steps.extract_version.outputs.version_number }}"
+    - name: Configure Git
+      run: >-
+        git config user.name "Add Git Release Tag Action"
+        git config user.email "github.action@noreply.github.com"
+    - name: Authenticate with GitHub
+      uses: actions/checkout@v2
+      with:
+        token: ${{ secrets.PAT_FOR_TAGGING }}
+    - name: Add Git Tag - Release
+      run: >-
+        git tag -a "release-${{ steps.extract_version.outputs.version_number }}" -m "Release ${{ steps.extract_version.outputs.version_number }}"
+        git push origin --tags

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -53,11 +53,13 @@ jobs:
       uses: actions/checkout@v2
     - name: Extract Version Number
       id: extract_version
-      run: echo "::set-output name=version_number::$(grep -oP '(?<=<Version>)[^<]+' ADotNet/ADotNet.csproj)"
+      run: |-
+        echo "::set-output name=version_number::$(grep -oP '(?<=<Version>)[^<]+' ADotNet/ADotNet.csproj)"
     - name: Print Version Number
-      run: echo "Version number is ${{ steps.extract_version.outputs.version_number }}"
+      run: |-
+        echo "Version number is ${{ steps.extract_version.outputs.version_number }}"
     - name: Configure Git
-      run: >-
+      run: |-
         git config user.name "Add Git Release Tag Action"
         git config user.email "github.action@noreply.github.com"
     - name: Authenticate with GitHub
@@ -65,6 +67,6 @@ jobs:
       with:
         token: ${{ secrets.PAT_FOR_TAGGING }}
     - name: Add Git Tag - Release
-      run: >-
+      run: |-
         git tag -a "release-${{ steps.extract_version.outputs.version_number }}" -m "Release ${{ steps.extract_version.outputs.version_number }}"
         git push origin --tags

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -53,7 +53,7 @@ jobs:
       uses: actions/checkout@v2
     - name: Extract Version Number
       id: extract_version
-      run: echo "::set-output name=version_number::$(grep -oP '(?<=<Version>)[^<]+' BuildTestApp/BuildTestApp.csproj)"
+      run: echo "::set-output name=version_number::$(grep -oP '(?<=<Version>)[^<]+' ADotNet/ADotNet.csproj)"
     - name: Print Version Number
       run: echo "Version number is ${{ steps.extract_version.outputs.version_number }}"
     - name: Configure Git

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -6,6 +6,11 @@ on:
     branches:
     - master
   pull_request:
+    types:
+    - opened
+    - synchronize
+    - reopened
+    - closed
     branches:
     - master
 env:

--- a/ADotNet.Infrastructure.Build/Program.cs
+++ b/ADotNet.Infrastructure.Build/Program.cs
@@ -86,7 +86,7 @@ namespace ADotNet.Infrastructure.Build
                     {
                         If =
                         "github.event.pull_request.merged &&\r"
-                        + "github.event.pull_request.base.ref == 'main' &&\r"
+                        + "github.event.pull_request.base.ref == 'master' &&\r"
                         + "startsWith(github.event.pull_request.title, 'RELEASES:') &&\r"
                         + "contains(github.event.pull_request.labels.*.name, 'RELEASES')\r",
 

--- a/ADotNet.Infrastructure.Build/Program.cs
+++ b/ADotNet.Infrastructure.Build/Program.cs
@@ -33,6 +33,7 @@ namespace ADotNet.Infrastructure.Build
 
                     PullRequest = new PullRequestEvent
                     {
+                        Types = new string[] { "opened", "synchronize", "reopened", "closed" },
                         Branches = new string[] { "master" }
                     }
                 },

--- a/ADotNet.Infrastructure.Build/Program.cs
+++ b/ADotNet.Infrastructure.Build/Program.cs
@@ -93,6 +93,8 @@ namespace ADotNet.Infrastructure.Build
 
                         RunsOn = BuildMachines.UbuntuLatest,
 
+                        Needs = new string[] { "build" },
+
                         Steps = new List<GithubTask>
                         {
                             new CheckoutTaskV2

--- a/ADotNet.Infrastructure.Build/Program.cs
+++ b/ADotNet.Infrastructure.Build/Program.cs
@@ -81,6 +81,64 @@ namespace ADotNet.Infrastructure.Build
                                 Name = "Test"
                             }
                         }
+                    },
+                    AddTag = new TagJob
+                    {
+                        If =
+                        "github.event.pull_request.merged &&\r"
+                        + "github.event.pull_request.base.ref == 'main' &&\r"
+                        + "startsWith(github.event.pull_request.title, 'RELEASES:') &&\r"
+                        + "contains(github.event.pull_request.labels.*.name, 'RELEASES')\r",
+
+                        RunsOn = BuildMachines.UbuntuLatest,
+
+                        Steps = new List<GithubTask>
+                        {
+                            new CheckoutTaskV2
+                            {
+                                Name = "Checkout code"
+                            },
+
+                            new ShellScriptTask
+                            {
+                                Name = "Extract Version Number",
+                                Id = "extract_version",
+                                Run = "echo \"::set-output name=version_number::$(grep -oP '(?<=<Version>)[^<]+' BuildTestApp/BuildTestApp.csproj)\""
+                            },
+
+                            new ShellScriptTask
+                            {
+                                Name = "Print Version Number",
+                                Run = "echo \"Version number is ${{ steps.extract_version.outputs.version_number }}\""
+                            },
+
+                            new ShellScriptTask
+                            {
+                                Name = "Configure Git",
+                                Run =
+                                    "git config user.name \"Add Git Release Tag Action\""
+                                    + "\r"
+                                    + "git config user.email \"github.action@noreply.github.com\""
+                            },
+
+                            new CheckoutTaskV2
+                            {
+                                Name = "Authenticate with GitHub",
+                                With = new Dictionary<string, string>
+                                {
+                                    { "token", "${{ secrets.PAT_FOR_TAGGING }}" }
+                                }
+                            },
+
+                            new ShellScriptTask
+                            {
+                                Name = "Add Git Tag - Release",
+                                Run =
+                                    "git tag -a \"release-${{ steps.extract_version.outputs.version_number }}\" -m \"Release ${{ steps.extract_version.outputs.version_number }}\""
+                                    + "\r"
+                                    + "git push origin --tags"
+                            },
+                        }
                     }
                 }
             };

--- a/ADotNet.Infrastructure.Build/Program.cs
+++ b/ADotNet.Infrastructure.Build/Program.cs
@@ -103,7 +103,7 @@ namespace ADotNet.Infrastructure.Build
                             {
                                 Name = "Extract Version Number",
                                 Id = "extract_version",
-                                Run = "echo \"::set-output name=version_number::$(grep -oP '(?<=<Version>)[^<]+' BuildTestApp/BuildTestApp.csproj)\""
+                                Run = "echo \"::set-output name=version_number::$(grep -oP '(?<=<Version>)[^<]+' ADotNet/ADotNet.csproj)\""
                             },
 
                             new ShellScriptTask

--- a/ADotNet/Models/Pipelines/GithubPipelines/DotNets/Jobs.cs
+++ b/ADotNet/Models/Pipelines/GithubPipelines/DotNets/Jobs.cs
@@ -13,7 +13,7 @@ namespace ADotNet.Models.Pipelines.GithubPipelines.DotNets
         [YamlMember(Order = 0)]
         public BuildJob Build { get; set; }
 
-        [YamlMember(Order = 1, Alias = "add_tag")]
+        [YamlMember(Order = 1, Alias = "add_tag", DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)]
         public TagJob AddTag { get; set; }
     }
 }

--- a/ADotNet/Models/Pipelines/GithubPipelines/DotNets/Jobs.cs
+++ b/ADotNet/Models/Pipelines/GithubPipelines/DotNets/Jobs.cs
@@ -4,10 +4,16 @@
 // See License.txt in the project root for license information.
 // ---------------------------------------------------------------------------
 
+using YamlDotNet.Serialization;
+
 namespace ADotNet.Models.Pipelines.GithubPipelines.DotNets
 {
     public class Jobs
     {
+        [YamlMember(Order = 0)]
         public BuildJob Build { get; set; }
+
+        [YamlMember(Order = 1, Alias = "add_tag")]
+        public TagJob AddTag { get; set; }
     }
 }

--- a/ADotNet/Models/Pipelines/GithubPipelines/DotNets/PullRequestEvent.cs
+++ b/ADotNet/Models/Pipelines/GithubPipelines/DotNets/PullRequestEvent.cs
@@ -11,7 +11,10 @@ namespace ADotNet.Models.Pipelines.GithubPipelines.DotNets
 {
     public class PullRequestEvent
     {
-        [YamlMember(ScalarStyle = ScalarStyle.Folded)]
+        [YamlMember(Order = 0, ScalarStyle = ScalarStyle.Folded, DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)]
+        public string[] Types { get; set; }
+
+        [YamlMember(Order = 1, ScalarStyle = ScalarStyle.Folded)]
         public string[] Branches { get; set; }
     }
 }

--- a/ADotNet/Models/Pipelines/GithubPipelines/DotNets/TagJob.cs
+++ b/ADotNet/Models/Pipelines/GithubPipelines/DotNets/TagJob.cs
@@ -1,0 +1,27 @@
+// ---------------------------------------------------------------------------
+// Copyright (c) Hassan Habib & Shri Humrudha Jagathisun All rights reserved.
+// Licensed under the MIT License.
+// See License.txt in the project root for license information.
+// ---------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using ADotNet.Models.Pipelines.GithubPipelines.DotNets.Tasks;
+using YamlDotNet.Serialization;
+
+namespace ADotNet.Models.Pipelines.GithubPipelines.DotNets
+{
+    public class TagJob
+    {
+        [YamlMember(Order = 0, Alias = "if", DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)]
+        public string If { get; set; }
+
+        [YamlMember(Order = 1, Alias = "runs-on")]
+        public string RunsOn { get; set; }
+
+        [YamlMember(Order = 2, Alias = "env", DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)]
+        public Dictionary<string, string> EnvironmentVariables { get; set; }
+
+        [YamlMember(Order = 3)]
+        public List<GithubTask> Steps { get; set; }
+    }
+}

--- a/ADotNet/Models/Pipelines/GithubPipelines/DotNets/TagJob.cs
+++ b/ADotNet/Models/Pipelines/GithubPipelines/DotNets/TagJob.cs
@@ -18,10 +18,13 @@ namespace ADotNet.Models.Pipelines.GithubPipelines.DotNets
         [YamlMember(Order = 1, Alias = "runs-on")]
         public string RunsOn { get; set; }
 
-        [YamlMember(Order = 2, Alias = "env", DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)]
+        [YamlMember(Order = 2, Alias = "needs", DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)]
+        public string[] Needs { get; set; }
+
+        [YamlMember(Order = 3, Alias = "env", DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)]
         public Dictionary<string, string> EnvironmentVariables { get; set; }
 
-        [YamlMember(Order = 3)]
+        [YamlMember(Order = 4)]
         public List<GithubTask> Steps { get; set; }
     }
 }

--- a/ADotNet/Models/Pipelines/GithubPipelines/DotNets/Tasks/ShellScriptTask.cs
+++ b/ADotNet/Models/Pipelines/GithubPipelines/DotNets/Tasks/ShellScriptTask.cs
@@ -13,7 +13,7 @@ namespace ADotNet.Models.Pipelines.GithubPipelines.DotNets.Tasks
         [YamlMember(Order = 1, DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)]
         public string Id { get; set; }
 
-        [YamlMember(Order = 2, DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)]
+        [YamlMember(Order = 2, DefaultValuesHandling = DefaultValuesHandling.OmitDefaults, ScalarStyle = YamlDotNet.Core.ScalarStyle.Literal)]
         public string Run { get; set; }
     }
 }

--- a/ADotNet/Models/Pipelines/GithubPipelines/DotNets/Tasks/ShellScriptTask.cs
+++ b/ADotNet/Models/Pipelines/GithubPipelines/DotNets/Tasks/ShellScriptTask.cs
@@ -1,20 +1,19 @@
-﻿// ---------------------------------------------------------------------------
+// ---------------------------------------------------------------------------
 // Copyright (c) Hassan Habib & Shri Humrudha Jagathisun All rights reserved.
 // Licensed under the MIT License.
 // See License.txt in the project root for license information.
 // ---------------------------------------------------------------------------
 
-using System.Collections.Generic;
 using YamlDotNet.Serialization;
 
 namespace ADotNet.Models.Pipelines.GithubPipelines.DotNets.Tasks
 {
-    public class CheckoutTaskV2 : GithubTask
+    public class ShellScriptTask : GithubTask
     {
-        [YamlMember(Order = 1)]
-        public string Uses = "actions/checkout@v2";
+        [YamlMember(Order = 1, DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)]
+        public string Id { get; set; }
 
         [YamlMember(Order = 2, DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)]
-        public Dictionary<string, string> With { get; set; }
+        public string Run { get; set; }
     }
 }


### PR DESCRIPTION
Closes #58 

1. We are checking for case-insensitive labels. See https://docs.github.com/en/actions/learn-github-actions/expressions#contains.

2. The `add_tag` step will be skipped if the PR is not merged or is not merged against `master`:

![image](https://github.com/hassanhabib/ADotNet/assets/10738038/53b687da-8486-438b-a7fe-7d4c3dd72f51)

3. The `add_tag` step runs when the PR is merged against `master`:

![image](https://github.com/hassanhabib/ADotNet/assets/10738038/a4533515-8616-454d-a3bb-104b8a9f2dbc)
![image](https://github.com/hassanhabib/ADotNet/assets/10738038/e9d1f4f9-4bff-4464-84b9-c1ece16c955c)

