### PR TITLE
CONFIG: Added LangVersion to project file to enable multi-targeting on .netstandard2.0/2.1

### DIFF
--- a/ADotNet/ADotNet.csproj
+++ b/ADotNet/ADotNet.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+		<LangVersion>11.0</LangVersion>
 		<Copyright>Copyright (c) Hassan Habib &amp; Shri Humrudha</Copyright>
 		<Description>ADotNet is a dot net library to help engineers develop their build and release pipelines in C# without having to use YAML or any other technology.</Description>
 		<Authors>Hassan Habib &amp; Shri Humrudha</Authors>
@@ -42,8 +43,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Xeption" Version="1.7.0" />
-		<PackageReference Include="YamlDotNet" Version="11.2.1" />
+		<PackageReference Include="Xeption" Version="2.5.0" />
+		<PackageReference Include="YamlDotNet" Version="13.1.0" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Consider multi-targeting on .NetStandard 2.0 and 2.0 for maximum reach. I added the LangVersion=11 option to the project file to get around .NetStandard 2.0 limitations.

I also updated the nuget packages.

All unit tests pass.