### PR TITLE
INFRASTRUCTURE: Publish Job

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -46,7 +46,9 @@ jobs:
     runs-on: ubuntu-latest
     needs:
     - build
-    if: >
+    if: >-
+      needs.build.result == 'success' &&
+
       github.event.pull_request.merged &&
 
       github.event.pull_request.base.ref == 'master' &&
@@ -92,3 +94,23 @@ jobs:
           #### Release Notes
 
           ${{ steps.extract_version.outputs.package_release_notes }}
+  publish:
+    runs-on: ubuntu-latest
+    needs:
+    - add_tag
+    if: needs.add_tag.result == 'success'
+    steps:
+    - name: Check out
+      uses: actions/checkout@v3
+    - name: Setup .Net
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 7.0.201
+    - name: Restore
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --no-restore --configuration Release
+    - name: Pack NuGet Package
+      run: dotnet pack --configuration Release
+    - name: Push NuGet Package
+      run: dotnet nuget push **/bin/Release/**/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -47,13 +47,13 @@ jobs:
     needs:
     - build
     if: >-
-      needs.build.result == 'success' &&
+      needs.build.result == 'success' && 
 
-      github.event.pull_request.merged &&
+      github.event.pull_request.merged && 
 
-      github.event.pull_request.base.ref == 'master' &&
+      github.event.pull_request.base.ref == 'master' && 
 
-      startsWith(github.event.pull_request.title, 'RELEASES:') &&
+      startsWith(github.event.pull_request.title, 'RELEASES:') && 
 
       contains(github.event.pull_request.labels.*.name, 'RELEASES')
     steps:
@@ -75,7 +75,7 @@ jobs:
     - name: Authenticate with GitHub
       uses: actions/checkout@v3
       with:
-        token: ${{ secrets.PAT_FOR_TAGGING }}
+        token: ${{ secrets.GITHUB_PAT_FOR_TAGGING }}
     - name: Add Release Tag
       run: |-
         git tag -a "v${{ steps.extract_version.outputs.version_number }}" -m "Release - v${{ steps.extract_version.outputs.version_number }}"
@@ -83,7 +83,7 @@ jobs:
     - name: Create Release
       uses: actions/create-release@v1
       env:
-        GITHUB_TOKEN: ${{ secrets.PAT_FOR_TAGGING }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_PAT_FOR_TAGGING }}
       with:
         tag_name: v${{ steps.extract_version.outputs.version_number }}
         release_name: Release - v${{ steps.extract_version.outputs.version_number }}

--- a/ADotNet.Infrastructure.Build/Program.cs
+++ b/ADotNet.Infrastructure.Build/Program.cs
@@ -123,8 +123,7 @@ namespace ADotNet.Infrastructure.Build
                             {
                                 Name = "Configure Git",
                                 Run =
-                                    "git config user.name \"GitHub Action\""
-                                    + "\r"
+                                    "git config user.name \"GitHub Action\"\r"
                                     + "git config user.email \"action@github.com\""
                             },
 

--- a/ADotNet.Infrastructure.Build/Program.cs
+++ b/ADotNet.Infrastructure.Build/Program.cs
@@ -89,10 +89,11 @@ namespace ADotNet.Infrastructure.Build
                         Needs = new string[] { "build" },
 
                         If =
-                        "github.event.pull_request.merged &&\r"
-                        + "github.event.pull_request.base.ref == 'master' &&\r"
-                        + "startsWith(github.event.pull_request.title, 'RELEASES:') &&\r"
-                        + "contains(github.event.pull_request.labels.*.name, 'RELEASES')\r",
+                            "needs.build.result == 'success' &&\r"
+                            + "github.event.pull_request.merged &&\r"
+                            + "github.event.pull_request.base.ref == 'master' &&\r"
+                            + "startsWith(github.event.pull_request.title, 'RELEASES:') &&\r"
+                            + "contains(github.event.pull_request.labels.*.name, 'RELEASES')",
 
                         Steps = new List<GithubTask>
                         {
@@ -168,6 +169,54 @@ namespace ADotNet.Infrastructure.Build
                                 }
                             }
                         }
+                    },
+                    Publish = new PublishJob
+                    {
+                        RunsOn = BuildMachines.UbuntuLatest,
+                        Needs = new string[] { "add_tag" },
+
+                        If =
+                            "needs.add_tag.result == 'success'",
+
+                        Steps = new List<GithubTask> {
+                            new CheckoutTaskV3
+                            {
+                                Name = "Check out"
+                            },
+
+                            new SetupDotNetTaskV3
+                            {
+                                Name = "Setup .Net",
+
+                                TargetDotNetVersion = new TargetDotNetVersionV3
+                                {
+                                    DotNetVersion = "7.0.201"
+                                }
+                            },
+
+                            new RestoreTask
+                            {
+                                Name = "Restore"
+                            },
+
+                            new DotNetBuildTask
+                            {
+                                Name = "Build",
+                                Run = "dotnet build --no-restore --configuration Release"
+                            },
+
+                            new PackTask
+                            {
+                                Name = "Pack NuGet Package",
+
+                            },
+
+                            new NugetPushTask
+                            {
+                                Name = "Push NuGet Package",
+                            }
+
+                        },
                     }
                 }
             };

--- a/ADotNet/Models/Pipelines/GithubPipelines/DotNets/Jobs.cs
+++ b/ADotNet/Models/Pipelines/GithubPipelines/DotNets/Jobs.cs
@@ -17,6 +17,6 @@ namespace ADotNet.Models.Pipelines.GithubPipelines.DotNets
         public TagJob AddTag { get; set; }
 
         [YamlMember(Order = 2, Alias = "publish", DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)]
-        public TagJob Publish { get; set; }
+        public PublishJob Publish { get; set; }
     }
 }

--- a/ADotNet/Models/Pipelines/GithubPipelines/DotNets/Jobs.cs
+++ b/ADotNet/Models/Pipelines/GithubPipelines/DotNets/Jobs.cs
@@ -15,5 +15,8 @@ namespace ADotNet.Models.Pipelines.GithubPipelines.DotNets
 
         [YamlMember(Order = 1, Alias = "add_tag", DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)]
         public TagJob AddTag { get; set; }
+
+        [YamlMember(Order = 2, Alias = "publish", DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)]
+        public TagJob Publish { get; set; }
     }
 }

--- a/ADotNet/Models/Pipelines/GithubPipelines/DotNets/PublishJob.cs
+++ b/ADotNet/Models/Pipelines/GithubPipelines/DotNets/PublishJob.cs
@@ -1,0 +1,31 @@
+﻿// ---------------------------------------------------------------------------
+// Copyright (c) Hassan Habib & Shri Humrudha Jagathisun All rights reserved.
+// Licensed under the MIT License.
+// See License.txt in the project root for license information.
+// ---------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using ADotNet.Models.Pipelines.GithubPipelines.DotNets.Tasks;
+using YamlDotNet.Serialization;
+
+namespace ADotNet.Models.Pipelines.GithubPipelines.DotNets
+{
+    public class PublishJob
+    {
+        [YamlMember(Order = 0, Alias = "runs-on")]
+        public string RunsOn { get; set; }
+
+        [YamlMember(Order = 1, Alias = "needs", DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)]
+        public string[] Needs { get; set; }
+
+        [YamlMember(Order = 2, Alias = "if", DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)]
+        public string If { get; set; }
+
+        [YamlMember(Order = 3, Alias = "env", DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)]
+        public Dictionary<string, string> EnvironmentVariables { get; set; }
+
+        [YamlMember(Order = 4)]
+        public List<GithubTask> Steps { get; set; }
+    }
+}
+

--- a/ADotNet/Models/Pipelines/GithubPipelines/DotNets/Tasks/NugetPushTask.cs
+++ b/ADotNet/Models/Pipelines/GithubPipelines/DotNets/Tasks/NugetPushTask.cs
@@ -1,0 +1,16 @@
+﻿// ---------------------------------------------------------------------------
+// Copyright (c) Hassan Habib & Shri Humrudha Jagathisun All rights reserved.
+// Licensed under the MIT License.
+// See License.txt in the project root for license information.
+// ---------------------------------------------------------------------------
+
+using YamlDotNet.Serialization;
+
+namespace ADotNet.Models.Pipelines.GithubPipelines.DotNets.Tasks
+{
+    public class NugetPushTask : GithubTask
+    {
+        [YamlMember(Order = 1)]
+        public string Run = "dotnet nuget push **/bin/Release/**/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }}";
+    }
+}

--- a/ADotNet/Models/Pipelines/GithubPipelines/DotNets/Tasks/PackNugetTask.cs
+++ b/ADotNet/Models/Pipelines/GithubPipelines/DotNets/Tasks/PackNugetTask.cs
@@ -1,0 +1,16 @@
+﻿// ---------------------------------------------------------------------------
+// Copyright (c) Hassan Habib & Shri Humrudha Jagathisun All rights reserved.
+// Licensed under the MIT License.
+// See License.txt in the project root for license information.
+// ---------------------------------------------------------------------------
+
+using YamlDotNet.Serialization;
+
+namespace ADotNet.Models.Pipelines.GithubPipelines.DotNets.Tasks
+{
+    public class PackTask : GithubTask
+    {
+        [YamlMember(Order = 1)]
+        public string Run = "dotnet pack --configuration Release";
+    }
+}


### PR DESCRIPTION
Closes #73 
Closes #50

## This PR will allow publishing of a Nuget package after a release tag has been added.

### Prerequisites

#### Generate GitHub fine-grained personal access tokens
- Keys can be generated here: [https://github.com/settings/tokens?type=beta](https://github.com/settings/tokens?type=beta)
    - Token name -> Your repo name + " - Token for Tagging" e.g. `ADotNet - Token For Tagging`
    - Expiration -> 365 days
    - Repository access -> `Only select repositories` -> `ADotNet`
    - Permissions-> `Repository permissions`
        - Contents -> read and write
        - Pull Requests -> read and write
- Copy the generated token
- Go to `Settings` on your repo, then `Secrets and variables` > `Actions`
- Click on `New repository secret` and use `GITHUB_PAT_FOR_TAGGING` as name and the generated token as the value.

#### NuGet API keys
- Keys can be generated here: [https://www.nuget.org/account/apikeys](https://www.nuget.org/account/apikeys)
    - Key Name -> Your repo name
    - Expires In -> 365 days
    - Scope -> `Push new packages and package versions`
    - Packages -> Limit
- Copy the generated token
- Go to `Settings` on your repo, then `Secrets and variables` > `Actions`
- Click on `New repository secret` and use `NUGET_API_KEY` as name and the generated token as the value.

# 

![image](https://github.com/hassanhabib/ADotNet/assets/797750/6eb7e3bb-f5b9-4831-80ac-acd62d28d246)

![image](https://github.com/hassanhabib/ADotNet/assets/797750/c877957f-0851-4c22-aca7-154b375c05a7)

![image](https://github.com/hassanhabib/ADotNet/assets/797750/9877db3d-3206-46b9-9c43-a42231211f85)

![image](https://github.com/hassanhabib/ADotNet/assets/797750/b61c283a-21a8-4172-ac18-47beeb9abe0f)
