### PR TITLE
RELEASES: v2.2.0.0

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -47,13 +47,13 @@ jobs:
     needs:
     - build
     if: >-
-      needs.build.result == 'success' && 
+      needs.build.result == 'success' &&
 
-      github.event.pull_request.merged && 
+      github.event.pull_request.merged &&
 
-      github.event.pull_request.base.ref == 'master' && 
+      github.event.pull_request.base.ref == 'master' &&
 
-      startsWith(github.event.pull_request.title, 'RELEASES:') && 
+      startsWith(github.event.pull_request.title, 'RELEASES:') &&
 
       contains(github.event.pull_request.labels.*.name, 'RELEASES')
     steps:
@@ -75,7 +75,7 @@ jobs:
     - name: Authenticate with GitHub
       uses: actions/checkout@v3
       with:
-        token: ${{ secrets.GITHUB_PAT_FOR_TAGGING }}
+        token: ${{ secrets.PAT_FOR_TAGGING }}
     - name: Add Release Tag
       run: |-
         git tag -a "v${{ steps.extract_version.outputs.version_number }}" -m "Release - v${{ steps.extract_version.outputs.version_number }}"
@@ -83,7 +83,7 @@ jobs:
     - name: Create Release
       uses: actions/create-release@v1
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_PAT_FOR_TAGGING }}
+        GITHUB_TOKEN: ${{ secrets.PAT_FOR_TAGGING }}
       with:
         tag_name: v${{ steps.extract_version.outputs.version_number }}
         release_name: Release - v${{ steps.extract_version.outputs.version_number }}

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -75,7 +75,7 @@ jobs:
     - name: Authenticate with GitHub
       uses: actions/checkout@v3
       with:
-        token: ${{ secrets.NUGET_ACCESS }}
+        token: ${{ secrets.PAT_FOR_TAGGING }}
     - name: Add Release Tag
       run: |-
         git tag -a "v${{ steps.extract_version.outputs.version_number }}" -m "Release - v${{ steps.extract_version.outputs.version_number }}"
@@ -83,7 +83,7 @@ jobs:
     - name: Create Release
       uses: actions/create-release@v1
       env:
-        GITHUB_TOKEN: ${{ secrets.NUGET_ACCESS }}
+        GITHUB_TOKEN: ${{ secrets.PAT_FOR_TAGGING }}
       with:
         tag_name: v${{ steps.extract_version.outputs.version_number }}
         release_name: Release - v${{ steps.extract_version.outputs.version_number }}
@@ -113,4 +113,4 @@ jobs:
     - name: Pack NuGet Package
       run: dotnet pack --configuration Release
     - name: Push NuGet Package
-      run: dotnet nuget push **/bin/Release/**/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }}
+      run: dotnet nuget push **/bin/Release/**/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_ACCESS }}

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -75,7 +75,7 @@ jobs:
     - name: Authenticate with GitHub
       uses: actions/checkout@v3
       with:
-        token: ${{ secrets.PAT_FOR_TAGGING }}
+        token: ${{ secrets.NUGET_ACCESS }}
     - name: Add Release Tag
       run: |-
         git tag -a "v${{ steps.extract_version.outputs.version_number }}" -m "Release - v${{ steps.extract_version.outputs.version_number }}"
@@ -83,7 +83,7 @@ jobs:
     - name: Create Release
       uses: actions/create-release@v1
       env:
-        GITHUB_TOKEN: ${{ secrets.PAT_FOR_TAGGING }}
+        GITHUB_TOKEN: ${{ secrets.NUGET_ACCESS }}
       with:
         tag_name: v${{ steps.extract_version.outputs.version_number }}
         release_name: Release - v${{ steps.extract_version.outputs.version_number }}

--- a/ADotNet.Infrastructure.Build/ADotNet.Infrastructure.Build.csproj
+++ b/ADotNet.Infrastructure.Build/ADotNet.Infrastructure.Build.csproj
@@ -1,12 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
-  </PropertyGroup>
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net7.0</TargetFramework>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\ADotNet\ADotNet.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\ADotNet\ADotNet.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/ADotNet.Infrastructure.Build/Program.cs
+++ b/ADotNet.Infrastructure.Build/Program.cs
@@ -132,7 +132,7 @@ namespace ADotNet.Infrastructure.Build
                                 Name = "Authenticate with GitHub",
                                 With = new Dictionary<string, string>
                                 {
-                                    { "token", "${{ secrets.GITHUB_PAT_FOR_TAGGING }}" }
+                                    { "token", "${{ secrets.NUGET_ACCESS }}" }
                                 }
                             },
 
@@ -151,7 +151,7 @@ namespace ADotNet.Infrastructure.Build
 
                                 EnvironmentVariables = new Dictionary<string, string>
                                 {
-                                    { "GITHUB_TOKEN", "${{ secrets.GITHUB_PAT_FOR_TAGGING }}" }
+                                    { "GITHUB_TOKEN", "${{ secrets.NUGET_ACCESS }}" }
                                 },
 
                                 With = new Dictionary<string, string>

--- a/ADotNet.Infrastructure.Build/Program.cs
+++ b/ADotNet.Infrastructure.Build/Program.cs
@@ -132,7 +132,7 @@ namespace ADotNet.Infrastructure.Build
                                 Name = "Authenticate with GitHub",
                                 With = new Dictionary<string, string>
                                 {
-                                    { "token", "${{ secrets.NUGET_ACCESS }}" }
+                                    { "token", "${{ secrets.PAT_FOR_TAGGING }}" }
                                 }
                             },
 
@@ -151,7 +151,7 @@ namespace ADotNet.Infrastructure.Build
 
                                 EnvironmentVariables = new Dictionary<string, string>
                                 {
-                                    { "GITHUB_TOKEN", "${{ secrets.NUGET_ACCESS }}" }
+                                    { "GITHUB_TOKEN", "${{ secrets.PAT_FOR_TAGGING }}" }
                                 },
 
                                 With = new Dictionary<string, string>

--- a/ADotNet.Infrastructure.Build/Program.cs
+++ b/ADotNet.Infrastructure.Build/Program.cs
@@ -132,7 +132,7 @@ namespace ADotNet.Infrastructure.Build
                                 Name = "Authenticate with GitHub",
                                 With = new Dictionary<string, string>
                                 {
-                                    { "token", "${{ secrets.PAT_FOR_TAGGING }}" }
+                                    { "token", "${{ secrets.GITHUB_PAT_FOR_TAGGING }}" }
                                 }
                             },
 
@@ -151,7 +151,7 @@ namespace ADotNet.Infrastructure.Build
 
                                 EnvironmentVariables = new Dictionary<string, string>
                                 {
-                                    { "GITHUB_TOKEN", "${{ secrets.PAT_FOR_TAGGING }}" }
+                                    { "GITHUB_TOKEN", "${{ secrets.GITHUB_PAT_FOR_TAGGING }}" }
                                 },
 
                                 With = new Dictionary<string, string>

--- a/ADotNet/ADotNet.csproj
+++ b/ADotNet/ADotNet.csproj
@@ -3,18 +3,26 @@
 	<PropertyGroup>
 		<TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
 		<LangVersion>11.0</LangVersion>
-		<Copyright>Copyright (c) Hassan Habib &amp; Shri Humrudha</Copyright>
+		<Copyright>Copyright (c) Hassan Habib &amp; Shri Humrudha &amp; Christo du Toit</Copyright>
 		<Description>ADotNet is a dot net library to help engineers develop their build and release pipelines in C# without having to use YAML or any other technology.</Description>
-		<Authors>Hassan Habib &amp; Shri Humrudha</Authors>
+		<Authors>Hassan Habib &amp; Shri Humrudha &amp; Christo du Toit</Authors>
 		<PackageIcon>ADotNet.png</PackageIcon>
 		<RepositoryUrl>https://github.com/hassanhabib/ADotNet</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<PackageTags>ADO YAML AzureDevOps</PackageTags>
-		<PackageReleaseNotes>Add Windows-Latest VM + RunTask + Environment Variables</PackageReleaseNotes>
+		<PackageReleaseNotes>
+			Adding Release Tag, GitHub Release, and NuGet Package Push Support
+
+			We are excited to announce the addition of new functionality to our software, 
+			enabling developers to enhance their release management process. 
+			With this update, you can now easily add release tags, create GitHub releases, 
+			and push packages to NuGet for release builds. 
+			Upgrade today to leverage these powerful features and improve your development workflow.
+		</PackageReleaseNotes>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-		<AssemblyVersion>2.1.1.3</AssemblyVersion>
-		<FileVersion>2.1.1.3</FileVersion>
-		<Version>2.1.1.3</Version>
+		<AssemblyVersion>2.2.0.0</AssemblyVersion>
+		<FileVersion>2.2.0.0</FileVersion>
+		<Version>2.2.0.0</Version>
 		<PackageLicenseFile>License.txt</PackageLicenseFile>
 		<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
 		<PackageProjectUrl>https://github.com/hassanhabib/ADotNet</PackageProjectUrl>

--- a/ADotNet/Models/Pipelines/GithubPipelines/DotNets/Tasks/NugetPushTask.cs
+++ b/ADotNet/Models/Pipelines/GithubPipelines/DotNets/Tasks/NugetPushTask.cs
@@ -11,6 +11,6 @@ namespace ADotNet.Models.Pipelines.GithubPipelines.DotNets.Tasks
     public class NugetPushTask : GithubTask
     {
         [YamlMember(Order = 1)]
-        public string Run = "dotnet nuget push **/bin/Release/**/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }}";
+        public string Run = "dotnet nuget push **/bin/Release/**/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_ACCESS }}";
     }
 }

--- a/AdoNet.Tests.Console/ADotNet.Tests.Console.csproj
+++ b/AdoNet.Tests.Console/ADotNet.Tests.Console.csproj
@@ -1,12 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
-  </PropertyGroup>
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net7.0</TargetFramework>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\ADotNet\ADotNet.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\ADotNet\ADotNet.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/AdoNet.Tests.Unit/ADotNet.Tests.Unit.csproj
+++ b/AdoNet.Tests.Unit/ADotNet.Tests.Unit.csproj
@@ -1,29 +1,28 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+	<PropertyGroup>
+		<TargetFramework>net7.0</TargetFramework>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
 
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="FluentAssertions" Version="6.5.1" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0-preview-20220131-20" />
+		<PackageReference Include="Moq" Version="4.17.1" />
+		<PackageReference Include="Tynamix.ObjectFiller" Version="1.5.7" />
+		<PackageReference Include="xunit" Version="2.4.2-pre.12" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="coverlet.collector" Version="3.1.2">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.5.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0-preview-20220131-20" />
-    <PackageReference Include="Moq" Version="4.17.1" />
-    <PackageReference Include="Tynamix.ObjectFiller" Version="1.5.7" />
-    <PackageReference Include="xunit" Version="2.4.2-pre.12" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\ADotNet\ADotNet.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\ADotNet\ADotNet.csproj" />
+	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
Closes #73 
Closes #50

## This PR will allow publishing of a Nuget package after a release tag has been added.

### Prerequisites

#### Generate GitHub fine-grained personal access tokens
- Keys can be generated here: [https://github.com/settings/tokens?type=beta](https://github.com/settings/tokens?type=beta)
    - Token name -> Your repo name + " - Token for Tagging" e.g. `ADotNet - Token For Tagging`
    - Expiration -> 365 days
    - Repository access -> `Only select repositories` -> `ADotNet`
    - Permissions-> `Repository permissions`
        - Contents -> read and write
        - Pull Requests -> read and write
- Copy the generated token
- Go to `Settings` on your repo, then `Secrets and variables` > `Actions`
- Click on `New repository secret` and use `GITHUB_PAT_FOR_TAGGING` as name and the generated token as the value.

#### NuGet API keys
- Keys can be generated here: [https://www.nuget.org/account/apikeys](https://www.nuget.org/account/apikeys)
    - Key Name -> Your repo name
    - Expires In -> 365 days
    - Scope -> `Push new packages and package versions`
    - Packages -> Limit
- Copy the generated token
- Go to `Settings` on your repo, then `Secrets and variables` > `Actions`
- Click on `New repository secret` and use `NUGET_API_KEY` as name and the generated token as the value.

