### PR TITLE
MINOR FIX: Fixed issue where multiline release notes was shown as an empty string in release summary

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -59,15 +59,18 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
-    - name: Extract Version Number
+    - name: Extract Version Number and Release Notes
       id: extract_version
       run: |-
         echo "version_number=$(grep -oP '(?<=<Version>)[^<]+' ADotNet/ADotNet.csproj)" >> $GITHUB_OUTPUT
-        echo "package_release_notes=$(grep -oP '(?<=<PackageReleaseNotes>)[^<]+' ADotNet/ADotNet.csproj)" >> $GITHUB_OUTPUT
-    - name: Print Version Number
+        package_release_notes=$(awk -v RS='' -F'</?PackageReleaseNotes>' 'NF>1{print $2}' BuildTestApp/BuildTestApp.csproj | sed -e 's/^[[:space:]]*//')
+        echo 'package_release_notes<<EOF' >> $GITHUB_ENV
+        echo -e "$package_release_notes" >> $GITHUB_ENV
+        echo 'EOF' >> $GITHUB_ENV
+    - name: Print Extract Version Number and Release Notes
       run: |-
         echo "Version number - v${{ steps.extract_version.outputs.version_number }}"
-        echo "Release Notes - ${{ steps.extract_version.outputs.package_release_notes }}"
+        echo "Release Notes - ${{ env.package_release_notes }}"
     - name: Configure Git
       run: |-
         git config user.name "GitHub Action"
@@ -88,12 +91,12 @@ jobs:
         tag_name: v${{ steps.extract_version.outputs.version_number }}
         release_name: Release - v${{ steps.extract_version.outputs.version_number }}
         body: >-
-          ### Release - v${{ steps.extract_version.outputs.version_number }}
+          ## Release - v${{ steps.extract_version.outputs.version_number }}
 
 
-          #### Release Notes
+          ### Release Notes
 
-          ${{ steps.extract_version.outputs.package_release_notes }}
+          ${{ env.package_release_notes }}
   publish:
     runs-on: ubuntu-latest
     needs:


### PR DESCRIPTION
The previous code did not read the release notes correctly.

This version will correctly read the multiline release notes from this tag in the `.csproj` file and remove the leading whitespaces as added by formatting of the project file.

```
<PackageReleaseNotes>
	Adding Release Tag, GitHub Release, and NuGet Package Push Support

	We are excited to announce the addition of new functionality to our software, 
	enabling developers to enhance their release management process. 
	With this update, you can now easily add release tags, create GitHub releases, 
	and push packages to NuGet for release builds. 
	Upgrade today to leverage these powerful features and improve your development workflow.
</PackageReleaseNotes>
```