### PR TITLE
FOUNDATIONS: Check PR Title Job

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -37,6 +37,9 @@ jobs:
         PR_TITLE="${{ github.event.pull_request.title }}"
 
 
+        echo "PR Title: ${{ github.event.pull_request.title }}"
+
+
         # Define the list of prefixes
 
         PREFIXES=(
@@ -91,6 +94,9 @@ jobs:
         if [ "${PREFIX_MATCH}" == false ]; then
             echo "error: The PR title must start with one of THE STANDARD specified prefixes.  Current PR Title: '${{ github.event.pull_request.title }}'"
             echo "See https://github.com/hassanhabib/The-Standard-Team/blob/main/4%20Practices/4%20Practices.md#4113-category-list for the complete category list"
+            echo ""
+            echo "Please update the PR Title to the correct category, then navigate to the Actions tab and click on the Re-run jobs button"
+            echo "P.S. if the job fails again with the wrong title, give it a few minutes to allow the PR Title Change event to propagate through the system."
             exit 1
         fi
   build:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -27,8 +27,76 @@ env:
       )
     }}
 jobs:
+  check_pr_title:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+    - name: Check PR Title
+      run: >-
+        PR_TITLE="${{ github.event.pull_request.title }}"
+
+
+        # Define the list of prefixes
+
+        PREFIXES=(
+            "ACCEPTANCE"
+            "AGGREGATION"
+            "BASE"
+            "BROKER"
+            "BUSINESS"
+            "CODE RUB"
+            "COMPONENT"
+            "CONFIG"
+            "CONTROLLER"
+            "COORDINATION"
+            "CLIENT"
+            "DATA"
+            "DESIGN"
+            "DOCUMENTATION"
+            "EXPOSER"
+            "FOUNDATION"
+            "INFRA"
+            "INTEGRATION"
+            "MAJORFIX"
+            "MANAGEMENT"
+            "MEDIUMFIX"
+            "MINORFIX"
+            "ORCHESTRATION"
+            "PAGE"
+            "PROCESSING"
+            "PROVISION"
+            "RELEASE"
+            "STANDARD"
+            "VIEW"
+        )
+
+
+        # Check if the PR title starts with any of the prefixes
+
+        PREFIX_MATCH=false
+
+        for PREFIX in "${PREFIXES[@]}"
+
+        do
+            if [[ "${PR_TITLE}" == "${PREFIX}"* ]]; then
+                PREFIX_MATCH=true
+                break
+            fi
+        done
+
+
+        # Fail the workflow if no prefix match is found
+
+        if [ "${PREFIX_MATCH}" == false ]; then
+            echo "error: The PR title must start with one of THE STANDARD specified prefixes.  Current PR Title: '${{ github.event.pull_request.title }}'"
+            echo "See https://github.com/hassanhabib/The-Standard-Team/blob/main/4%20Practices/4%20Practices.md#4113-category-list for the complete category list"
+            exit 1
+        fi
   build:
     runs-on: ubuntu-latest
+    needs:
+    - check_pr_title
     steps:
     - name: Check out
       uses: actions/checkout@v3

--- a/ADotNet.Infrastructure.Build/Program.cs
+++ b/ADotNet.Infrastructure.Build/Program.cs
@@ -9,7 +9,6 @@ using System.IO;
 using ADotNet.Clients;
 using ADotNet.Models.Pipelines.GithubPipelines.DotNets;
 using ADotNet.Models.Pipelines.GithubPipelines.DotNets.Tasks;
-using ADotNet.Models.Pipelines.GithubPipelines.DotNets.Tasks.SetupDotNetTaskV1s;
 using ADotNet.Models.Pipelines.GithubPipelines.DotNets.Tasks.SetupDotNetTaskV3s;
 
 namespace ADotNet.Infrastructure.Build
@@ -47,10 +46,16 @@ namespace ADotNet.Infrastructure.Build
                 Jobs = new Dictionary<string, Job>
                 {
                     {
+                        "check_pr_title",
+                        new CheckPrTitleJob(
+                            runsOn: BuildMachines.UbuntuLatest)
+                    },
+                    {
                         "build",
                         new Job
                         {
                             RunsOn = BuildMachines.UbuntuLatest,
+                            Needs = new string[] { "check_pr_title" },
 
                             Steps = new List<GithubTask>
                             {

--- a/ADotNet/Models/Pipelines/GithubPipelines/DotNets/CheckPRTitleJob.cs
+++ b/ADotNet/Models/Pipelines/GithubPipelines/DotNets/CheckPRTitleJob.cs
@@ -1,0 +1,120 @@
+// ---------------------------------------------------------------------------
+// Copyright (c) Hassan Habib & Shri Humrudha Jagathisun All rights reserved.
+// Licensed under the MIT License.
+// See License.txt in the project root for license information.
+// ---------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.ComponentModel;
+using ADotNet.Models.Pipelines.GithubPipelines.DotNets.Tasks;
+using YamlDotNet.Serialization;
+
+namespace ADotNet.Models.Pipelines.GithubPipelines.DotNets
+{
+    public sealed class CheckPrTitleJob : Job
+    {
+        public CheckPrTitleJob(
+            string runsOn)
+        {
+            RunsOn = runsOn;
+
+            Steps = new List<GithubTask>
+                {
+                    new CheckoutTaskV3
+                    {
+                        Name = "Checkout code",
+                    },
+
+                    new GithubTask()
+                    {
+                        Name = "Check PR Title",
+                        Run = @"PR_TITLE=""${{ github.event.pull_request.title }}""
+
+# Define the list of prefixes
+PREFIXES=(
+    ""ACCEPTANCE""
+    ""AGGREGATION""
+    ""BASE""
+    ""BROKER""
+    ""BUSINESS""
+    ""CODE RUB""
+    ""COMPONENT""
+    ""CONFIG""
+    ""CONTROLLER""
+    ""COORDINATION""
+    ""CLIENT""
+    ""DATA""
+    ""DESIGN""
+    ""DOCUMENTATION""
+    ""EXPOSER""
+    ""FOUNDATION""
+    ""INFRA""
+    ""INTEGRATION""
+    ""MAJORFIX""
+    ""MANAGEMENT""
+    ""MEDIUMFIX""
+    ""MINORFIX""
+    ""ORCHESTRATION""
+    ""PAGE""
+    ""PROCESSING""
+    ""PROVISION""
+    ""RELEASE""
+    ""STANDARD""
+    ""VIEW""
+)
+
+# Check if the PR title starts with any of the prefixes
+PREFIX_MATCH=false
+for PREFIX in ""${PREFIXES[@]}""
+do
+    if [[ ""${PR_TITLE}"" == ""${PREFIX}""* ]]; then
+        PREFIX_MATCH=true
+        break
+    fi
+done
+
+# Fail the workflow if no prefix match is found
+if [ ""${PREFIX_MATCH}"" == false ]; then
+    echo ""error: The PR title must start with one of THE STANDARD specified prefixes.  Current PR Title: '${{ github.event.pull_request.title }}'""
+    echo ""See https://github.com/hassanhabib/The-Standard-Team/blob/main/4%20Practices/4%20Practices.md#4113-category-list for the complete category list""
+    exit 1
+fi"
+                    },
+                };
+        }
+
+        [YamlMember(Order = 0, DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)]
+        public new string Name { get; set; }
+
+        [YamlMember(Order = 1, Alias = "runs-on")]
+        public new string RunsOn { get; set; }
+
+        [YamlMember(Order = 2, Alias = "needs", DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)]
+        public new string[] Needs { get; set; }
+
+        [YamlMember(Order = 3, Alias = "if", DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)]
+        public new string If { get; set; }
+
+        [YamlMember(Order = 4, DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)]
+        public new string Environment { get; set; }
+
+        [YamlMember(Order = 5, DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)]
+        public new DefaultValues Defaults { get; set; }
+
+        [YamlMember(Order = 6)]
+        public new List<GithubTask> Steps { get; set; }
+
+        [DefaultValue(0)]
+        [YamlMember(Order = 7, Alias = "timeout-minutes", DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)]
+        public new int TimeoutInMinutes { get; set; }
+
+        [YamlMember(Order = 8, DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)]
+        public new Strategy Strategy { get; set; }
+
+        [YamlMember(Order = 9, Alias = "env", DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)]
+        public new Dictionary<string, string> EnvironmentVariables { get; set; }
+
+        [YamlMember(Order = 10, DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)]
+        public new Dictionary<string, string> Outputs { get; set; }
+    }
+}

--- a/ADotNet/Models/Pipelines/GithubPipelines/DotNets/CheckPRTitleJob.cs
+++ b/ADotNet/Models/Pipelines/GithubPipelines/DotNets/CheckPRTitleJob.cs
@@ -30,6 +30,8 @@ namespace ADotNet.Models.Pipelines.GithubPipelines.DotNets
                         Name = "Check PR Title",
                         Run = @"PR_TITLE=""${{ github.event.pull_request.title }}""
 
+echo ""PR Title: ${{ github.event.pull_request.title }}""
+
 # Define the list of prefixes
 PREFIXES=(
     ""ACCEPTANCE""
@@ -77,6 +79,9 @@ done
 if [ ""${PREFIX_MATCH}"" == false ]; then
     echo ""error: The PR title must start with one of THE STANDARD specified prefixes.  Current PR Title: '${{ github.event.pull_request.title }}'""
     echo ""See https://github.com/hassanhabib/The-Standard-Team/blob/main/4%20Practices/4%20Practices.md#4113-category-list for the complete category list""
+    echo """"
+    echo ""Please update the PR Title to the correct category, then navigate to the Actions tab and click on the Re-run jobs button""
+    echo ""P.S. if the job fails again with the wrong title, give it a few minutes to allow the PR Title Change event to propagate through the system.""
     exit 1
 fi"
                     },


### PR DESCRIPTION
This job will checkout that a PR has been created with one of THE STANDARD accepted categories mentioned here:
https://github.com/hassanhabib/The-Standard-Team/blob/main/4%20Practices/4%20Practices.md#4113-category-list

```
                Jobs = new Dictionary<string, Job>
                {
                    {
                        "check_pr_title",
                        new CheckPrTitleJob(
                            runsOn: BuildMachines.UbuntuLatest)
                    },
                    {
                        "build",
                        new Job
                        {
                            Needs = new string[] { "check_pr_title" },
                            . . . 
                        }
                    }
                }
```
STEPS:
- Add the "check_pr_title" job before existing jobs
- Optionally add `Needs = new string[] { "check_pr_title" },` to the job after this one, this will stop processing of subsequent jobs on fail.


Sample success message
![image](https://github.com/hassanhabib/ADotNet/assets/797750/2be1d167-b119-416e-9b53-a166f7cdc6e4)

![image](https://github.com/hassanhabib/ADotNet/assets/797750/159cc9b9-fccb-47e8-9646-ecf23961755c)


Sample error message
![image](https://github.com/hassanhabib/ADotNet/assets/797750/61d6c877-f8f7-491e-8843-764005eb8b64)

