### PR TITLE
FOUNDATIONS: Add RequireIssueOrTaskJobV2 with configurable excluded authors

### DIFF
--- a/ADotNet/Models/Pipelines/GithubPipelines/DotNets/RequireIssueOrTaskJobV2.cs
+++ b/ADotNet/Models/Pipelines/GithubPipelines/DotNets/RequireIssueOrTaskJobV2.cs
@@ -1,0 +1,141 @@
+// ---------------------------------------------------------------------------
+// Copyright (c) Hassan Habib & Shri Humrudha Jagathisun All rights reserved.
+// Licensed under the MIT License.
+// See License.txt in the project root for license information.
+// ---------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.ComponentModel;
+using ADotNet.Models.Pipelines.GithubPipelines.DotNets.Tasks;
+using YamlDotNet.Serialization;
+
+namespace ADotNet.Models.Pipelines.GithubPipelines.DotNets
+{
+    public sealed class RequireIssueOrTaskJobV2 : Job
+    {
+        // excludedAuthors is a CSV of PR author logins (e.g. "dependabot[bot]" or
+        // "app,dependabot[bot]"). The require-issue check is skipped - and the job
+        // still succeeds - when the PR author matches one of them.
+        public RequireIssueOrTaskJobV2(string excludedAuthors)
+        {
+            RunsOn = "ubuntu-latest";
+
+            Permissions = new Dictionary<string, string>
+            {
+                { "contents", "read" },
+                { "pull-requests", "read" }
+            };
+
+            var commaWrappedExcludedAuthors =
+                "," + (excludedAuthors ?? string.Empty).Replace(" ", string.Empty) + ",";
+
+            var runForNonExcludedAuthorsCondition =
+                "${{ !contains('" + commaWrappedExcludedAuthors
+                    + "', format(',{0},', steps.get_pr_info.outputs.prOwner)) }}";
+
+            Steps = new List<GithubTask>
+                {
+                    new CheckoutTaskV3
+                    {
+                        Name = "Check out"
+                    },
+
+                    new GithubTask()
+                    {
+                        Name = "Get PR Information",
+                        Id = "get_pr_info",
+                        Uses = "actions/github-script@v6",
+                        With = new Dictionary<string, string>
+                        {
+                            {
+                                "script",
+                                """
+                                    const pr = await github.rest.pulls.get({
+                                      owner: context.repo.owner,
+                                      repo: context.repo.repo,
+                                      pull_number: context.payload.pull_request.number
+                                    });
+
+                                    const prOwner = pr.data.user.login || "";
+                                    const prBody = pr.data.body || "";
+                                    core.setOutput("prOwner", prOwner);
+                                    core.setOutput("description", prBody);
+                                    console.log(`PR Owner: ${prOwner}`);
+                                    console.log(`PR Body: ${prBody}`);
+                                """
+                            }
+                        }
+                    },
+
+                    new GithubTask()
+                    {
+                        Name = "Check For Associated Issues Or Tasks",
+                        If = runForNonExcludedAuthorsCondition,
+                        Id = "check_for_issues_or_tasks",
+                        Shell = "bash",
+                        EnvironmentVariables = new Dictionary<string, string>
+                        {
+                            { "PR_BODY", "${{ steps.get_pr_info.outputs.description }}" }
+                        },
+                        Run =
+                            """
+                                if [[ -z "${PR_BODY:-}" ]]; then
+                                  echo "Error: PR description does not contain any links to issue(s)/task(s) (e.g., 'closes #123' / 'closes AB#123' / 'fixes #123' / 'fixes AB#123')."
+                                  exit 1
+                                fi
+
+                                NORMALIZED_PR_BODY=$(printf '%s' "$PR_BODY" | tr '\r\n' '  ' | tr -s ' ')
+
+                                if printf '%s' "$NORMALIZED_PR_BODY" | grep -Piq "(close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\s*(\[#[0-9]+\]|#[0-9]+|\[AB#[0-9]+\]|AB#[0-9]+)"; then
+                                  echo "Valid PR description."
+                                else
+                                  echo "Error: PR description does not contain any links to issue(s)/task(s) (e.g., 'closes #123' / 'closes AB#123' / 'fixes #123' / 'fixes AB#123')."
+                                  exit 1
+                                fi
+                            """,
+                    },
+            };
+        }
+
+        [YamlMember(Order = 0, DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)]
+        public new string Name { get; set; }
+
+        [YamlMember(Order = 1, Alias = "runs-on")]
+        public new string RunsOn { get; set; }
+
+        [YamlMember(Order = 2, Alias = "needs", DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)]
+        public new string[] Needs { get; set; }
+
+        [YamlMember(Order = 3, Alias = "if", DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)]
+        public new string If { get; set; }
+
+        [YamlMember(Order = 4, DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)]
+        public new string Environment { get; set; }
+
+        [YamlMember(Order = 5, DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)]
+        public new DefaultValues Defaults { get; set; }
+
+        [YamlMember(Order = 6)]
+        public new List<GithubTask> Steps { get; set; }
+
+        [DefaultValue(0)]
+        [YamlMember(Order = 7, Alias = "timeout-minutes", DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)]
+        public new int TimeoutInMinutes { get; set; }
+
+        [YamlMember(Order = 8, DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)]
+        public new Strategy Strategy { get; set; }
+
+        [YamlMember(Order = 9, Alias = "env", DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)]
+        public new Dictionary<string, string> EnvironmentVariables { get; set; }
+
+        [YamlMember(Order = 10, DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)]
+        public new Dictionary<string, string> Outputs { get; set; }
+
+        [DefaultValue(false)]
+        [YamlMember(Order = 11, Alias = "continue-on-error", DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)]
+        public new bool ContinueOnError { get; set; }
+
+        [YamlMember(Order = 12, Alias = "permissions", DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)]
+        public new Dictionary<string, string> Permissions { get; set; }
+    }
+}

--- a/AdoNet.Tests.Unit/Models/Pipelines/GithubPipelines/DotNets/RequireIssueOrTaskJobV2Tests.cs
+++ b/AdoNet.Tests.Unit/Models/Pipelines/GithubPipelines/DotNets/RequireIssueOrTaskJobV2Tests.cs
@@ -1,0 +1,57 @@
+// ---------------------------------------------------------------------------
+// Copyright (c) Hassan Habib & Shri Humrudha Jagathisun All rights reserved.
+// Licensed under the MIT License.
+// See License.txt in the project root for license information.
+// ---------------------------------------------------------------------------
+
+using System.Linq;
+using ADotNet.Models.Pipelines.GithubPipelines.DotNets;
+using ADotNet.Models.Pipelines.GithubPipelines.DotNets.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace ADotNet.Tests.Unit.Models.Pipelines.GithubPipelines.DotNets
+{
+    public class RequireIssueOrTaskJobV2Tests
+    {
+        [Fact]
+        public void ShouldComposeSingleExcludedAuthorIntoSkipCondition()
+        {
+            // given
+            string excludedAuthors = "dependabot[bot]";
+
+            string expectedCondition =
+                "${{ !contains(',dependabot[bot],', " +
+                    "format(',{0},', steps.get_pr_info.outputs.prOwner)) }}";
+
+            // when
+            var requireIssueOrTaskJobV2 = new RequireIssueOrTaskJobV2(excludedAuthors);
+
+            // then
+            GithubTask checkStep = requireIssueOrTaskJobV2.Steps
+                .Single(step => step.Id == "check_for_issues_or_tasks");
+
+            checkStep.If.Should().Be(expectedCondition);
+        }
+
+        [Fact]
+        public void ShouldComposeMultipleExcludedAuthorsAndStripSpaces()
+        {
+            // given
+            string excludedAuthors = "app, dependabot[bot]";
+
+            string expectedCondition =
+                "${{ !contains(',app,dependabot[bot],', " +
+                    "format(',{0},', steps.get_pr_info.outputs.prOwner)) }}";
+
+            // when
+            var requireIssueOrTaskJobV2 = new RequireIssueOrTaskJobV2(excludedAuthors);
+
+            // then
+            GithubTask checkStep = requireIssueOrTaskJobV2.Steps
+                .Single(step => step.Id == "check_for_issues_or_tasks");
+
+            checkStep.If.Should().Be(expectedCondition);
+        }
+    }
+}


### PR DESCRIPTION
Adds RequireIssueOrTaskJobV2, a copy of RequireIssueOrTaskJob whose constructor takes a CSV excludedAuthors list. When the PR author is in that list the require-issue check is skipped (the job still succeeds), so consumers choose which authors skip the issue/task requirement instead of the hardcoded dependabot[bot]. Data-driven guard uses contains() over a comma-wrapped list for exact-token matching. Includes RequireIssueOrTaskJobV2Tests covering single and multiple excluded authors. Builds across netstandard2.0;2.1;net10.0.